### PR TITLE
Introduce CLI and enable custom durations

### DIFF
--- a/src/pomodoro/__init__.py
+++ b/src/pomodoro/__init__.py
@@ -1,14 +1,28 @@
 """
 pomodoro is a super simple pomodoro timer.
 """
+import argparse
 import logging
-from datetime import timedelta
+import os
 
 import gi
 gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk
 
+from pomodoro import defaults
 from pomodoro.ui import MainWindow
+from pomodoro.options import PomodoroOptions
+
+
+DESCRIPTION = 'A simple Pomodoro timer.'
+DEFAULT_WORK_DURATION = \
+    os.environ.get('POMODORO_WORK_DURATION', defaults.WORK_DURATION)
+DEFAULT_BREAK_DURATION = \
+    os.environ.get('POMODORO_BREAK_DURATION', defaults.BREAK_DURATION)
+DEFAULT_LONG_BREAK_DURATION = \
+    os.environ.get('POMODORO_LONG_BREAK_DURATION', defaults.LONG_BREAK_DURATION)
+LOG_LEVEL = getattr(logging, os.environ.get('LOG_LEVEL', default='ERROR'))
 
 
 def get_logger():
@@ -17,22 +31,54 @@ def get_logger():
     """
     logger = logging.getLogger('pomodoro')
     logger.setLevel(logging.DEBUG)
+
     console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.ERROR)
+    console_handler.setLevel(LOG_LEVEL)
+
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     console_handler.setFormatter(formatter)
+
     logger.addHandler(console_handler)
     return logger
 
 
+def get_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        '-w', '--work-duration', '--work', type=int,
+        default=DEFAULT_WORK_DURATION,
+        help='Duration of work intervals in minutes',
+    )
+    parser.add_argument(
+        '-b', '--break-duration', '--break', type=int,
+        default=DEFAULT_BREAK_DURATION,
+        help='Duration of normal breaks in minutes',
+    )
+    parser.add_argument(
+        '-l', '--long-break-duration', '--long-break', type=int,
+        default=DEFAULT_LONG_BREAK_DURATION,
+        help='Duration of long breaks in minutes',
+    )
+    return parser
+
+
 def main():
     """Entrypoint for the application."""
-    logger = get_logger()
-    logger.info('Creating an intance of MainWindow')
-    win = MainWindow()
+    # set up root logger
+    _ = get_logger()
+    logger = logging.getLogger(__name__)
+
+    parser = get_parser()
+    options = parser.parse_args(namespace=PomodoroOptions())
+    logger.debug('Starting with options %s', options)
+
+    logger.info('Creating an instance of MainWindow')
+    win = MainWindow(options)
     win.connect("destroy", Gtk.main_quit)
+
     logger.info('Launching')
     win.show_all()
     Gtk.main()
+
     logger.info('All done')

--- a/src/pomodoro/defaults.py
+++ b/src/pomodoro/defaults.py
@@ -5,9 +5,10 @@ Constants used to configure pomodoro.
 WINDOW_TITLE = "Pomodoro Timer"
 STARTUP_MESSAGE = "Pomodoro Timer"
 LABEL_FONT = "44"
-WORK_DURATION = 25 * 60
-BREAK_DURATION = 5 * 60
-LONG_BREAK_DURATION = 30 * 60
 SOUND_PATH = "/usr/share/sounds/ubuntu/notifications"
 DONE_SOUND = f"{SOUND_PATH}/Amsterdam.ogg"
 START_SOUND = f"{SOUND_PATH}/Rhodes.ogg"
+
+WORK_DURATION = 15
+BREAK_DURATION = 3
+LONG_BREAK_DURATION = 20

--- a/src/pomodoro/options.py
+++ b/src/pomodoro/options.py
@@ -1,0 +1,32 @@
+"""
+Define an object used for common configuration options.
+"""
+from dataclasses import dataclass
+
+from pomodoro import defaults
+
+
+@dataclass
+class PomodoroOptions:
+    window_title: str = defaults.WINDOW_TITLE
+    startup_message: str = defaults.STARTUP_MESSAGE
+    label_font: str = defaults.LABEL_FONT
+
+    done_sound: str = defaults.DONE_SOUND
+    start_sound: str = defaults.START_SOUND
+
+    work_duration: int = defaults.WORK_DURATION
+    break_duration: int = defaults.BREAK_DURATION
+    long_break_duration: int = defaults.LONG_BREAK_DURATION
+
+    @property
+    def work_duration_seconds(self):
+        return self.work_duration * 60
+
+    @property
+    def break_duration_seconds(self):
+        return self.break_duration * 60
+
+    @property
+    def long_break_duration_seconds(self):
+        return self.long_break_duration * 60

--- a/src/pomodoro/ui.py
+++ b/src/pomodoro/ui.py
@@ -90,10 +90,16 @@ class MainWindow(BigLabelButtonWindow):
         super().__init__(options)
         self.logger.info('MainWindow: initializing')
 
-        self.work_button = self.add_button("Work", self.work_clicked)
-        self.break_button = self.add_button("Break", self.break_clicked)
+        self.work_button = self.add_button(
+            f"Work ({options.work_duration})", self.work_clicked
+        )
+        self.break_button = self.add_button(
+            f"Break ({options.break_duration})", self.break_clicked
+        )
         self.long_break_button = self.add_button(
-            "Long Break", self.long_break_clicked)
+            f"Long Break ({options.long_break_duration})",
+            self.long_break_clicked
+        )
         self.stop_button = self.add_button("Stop", self.stop_clicked)
 
         self.timer = Timer()


### PR DESCRIPTION
This PR introduces a command line parser and enables custom durations to be configured using this command line or environment variables.

```
pomodoro -h
usage: pomodoro [-h] [-w WORK_DURATION] [-b BREAK_DURATION]
                [-l LONG_BREAK_DURATION]

A simple Pomodoro timer.

optional arguments:
  -h, --help            show this help message and exit
  -w WORK_DURATION, --work-duration WORK_DURATION, --work WORK_DURATION
                        Duration of work intervals in minutes
  -b BREAK_DURATION, --break-duration BREAK_DURATION, --break BREAK_DURATION
                        Duration of normal breaks in minutes
  -l LONG_BREAK_DURATION, --long-break-duration LONG_BREAK_DURATION, --long-break LONG_BREAK_DURATION
                        Duration of long breaks in minutes
```